### PR TITLE
Ticket #6 : (fix) Context menu must be closed when navigating from in…

### DIFF
--- a/app/src/main/java/com/example/filemanager/Activities/HomeActivity.java
+++ b/app/src/main/java/com/example/filemanager/Activities/HomeActivity.java
@@ -2,7 +2,9 @@ package com.example.filemanager.Activities;
 
 import android.os.Bundle;
 import android.util.Log;
+import android.view.MenuItem;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.navigation.NavController;
@@ -13,7 +15,7 @@ import androidx.navigation.ui.NavigationUI;
 import com.example.filemanager.R;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
-public class HomeActivity extends AppCompatActivity  {
+public class HomeActivity extends AppCompatActivity implements BottomNavigationView.OnNavigationItemSelectedListener {
     private static final String TAG = "HomeActivity";
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -31,7 +33,19 @@ public class HomeActivity extends AppCompatActivity  {
             NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
             NavigationUI.setupWithNavController(navView, navController);
 
+        navView.setOnNavigationItemSelectedListener(this);
 
 
+    }
+    @Override
+    public boolean onNavigationItemSelected(@NonNull MenuItem item) {
+        Log.e(TAG, "onNavigationItemSelected: ");
+        switch (item.getItemId()){
+            case R.id.externalStorageFragment:
+                if(InternalStorageFragment.actionMode!=null)
+                    InternalStorageFragment.actionMode.finish();
+                break;
+        }
+        return true;
     }
 }

--- a/app/src/main/java/com/example/filemanager/Activities/InternalStorageFragment.java
+++ b/app/src/main/java/com/example/filemanager/Activities/InternalStorageFragment.java
@@ -39,7 +39,7 @@ public class InternalStorageFragment extends Fragment implements InternalStorage
     InternalStorageViewModel viewModel;
     InternalStorageAdapter fileAdapter;
     RecyclerView recyclerView;
-    ActionMode actionMode;
+    public static ActionMode actionMode;
 
     @Override
     public void onAttach(@NonNull Context context) {

--- a/app/src/main/res/menu/bottom_navigation_menu.xml
+++ b/app/src/main/res/menu/bottom_navigation_menu.xml
@@ -5,12 +5,16 @@
     <item
         android:id="@+id/internalStorageFragment"
         android:icon="@drawable/icon_internal_storage"
-        android:title="@string/bottom_nav_internalstore_title" />
+        android:title="@string/bottom_nav_internalstore_title"
+        android:enabled="true"
+        />
 
     <item
         android:id="@+id/externalStorageFragment"
         android:icon="@drawable/icon_external_storage"
-        android:title="@string/bottom_nav_externalstore_title" />
+        android:title="@string/bottom_nav_externalstore_title"
+        android:enabled="true"
+        />
 
 
 </menu>

--- a/app/src/main/res/navigation/bottom_navigation_graph.xml
+++ b/app/src/main/res/navigation/bottom_navigation_graph.xml
@@ -6,11 +6,15 @@
     <fragment
         android:id="@+id/internalStorageFragment"
         android:name="com.example.filemanager.Activities.InternalStorageFragment"
-        android:label="InternalStorageFragment" />
+        android:label="InternalStorageFragment"
+        android:enabled ="true"
+        />
 
     <fragment
         android:id="@+id/externalStorageFragment"
         android:name="com.example.filemanager.Activities.ExternalStorageFragment"
-        android:label="ExternalStorageFragment" />
+        android:label="ExternalStorageFragment"
+        android:enabled ="true"
+        />
 
 </navigation>


### PR DESCRIPTION
…ternal storage bottom navigation option to external storage option

- .setOnNavigationItemSelectedListener() is set in the HomeActivity after the nav controller for the bottom navigation
  was setup. When the listener detects a selection to the external storage option after the context menu was activated
  from internal stroage option, ActionMode.finish() is called to close the context menu. .finish() is called within .onNavigationItemSelected()