### PR TITLE
Closes #17 , fix: Display correct fragment when External Storage opti…

### DIFF
--- a/app/src/main/java/com/example/filemanager/Activities/HomeActivity.java
+++ b/app/src/main/java/com/example/filemanager/Activities/HomeActivity.java
@@ -31,21 +31,19 @@ public class HomeActivity extends AppCompatActivity implements BottomNavigationV
 
             NavController navController = Navigation.findNavController(this, R.id.nav_host_fragment_container);
             NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
+            navView.setOnNavigationItemSelectedListener(this);
             NavigationUI.setupWithNavController(navView, navController);
 
-        navView.setOnNavigationItemSelectedListener(this);
+
 
 
     }
     @Override
     public boolean onNavigationItemSelected(@NonNull MenuItem item) {
         Log.e(TAG, "onNavigationItemSelected: ");
-        switch (item.getItemId()){
-            case R.id.externalStorageFragment:
-                if(InternalStorageFragment.actionMode!=null)
+        if(item.getItemId()== R.id.externalStorageFragment && InternalStorageFragment.actionMode!=null)
                     InternalStorageFragment.actionMode.finish();
-                break;
-        }
+
         return true;
     }
 


### PR DESCRIPTION
…on is selected from bottom navigation

Solution:
In home activity java, the NavigationItemSelectedListener is set before NavigationUI.setupWithNavController() is called on line 34. Previously the listener was created after this method call and thats why the bottom navigation isn't displaying
the correct fragment